### PR TITLE
Don't sanitize in auto_link

### DIFF
--- a/lib/rails_rinku.rb
+++ b/lib/rails_rinku.rb
@@ -10,7 +10,6 @@ module RailsRinku
       options[:html] = args[1] || {}
     end
     options.reverse_merge!(:link => :all, :html => {})
-    text = sanitize(text) unless options[:sanitize] == false
 
     Rinku.auto_link(text, options[:link], tag_options(options[:html]), &block)
   end


### PR DESCRIPTION
Not sure why this is here. Core Rails's `auto_link` doesn't sanitize that I'm aware of. Definitely not under Rails <= 2.3.
