### PR TITLE
Rinku should escape unencoded Rails input

### DIFF
--- a/lib/rails_rinku.rb
+++ b/lib/rails_rinku.rb
@@ -13,11 +13,13 @@ module RailsRinku
     options.reverse_merge!(:link => :all, :html => {})
     text = h(text) unless text.html_safe?
 
-    Rinku.auto_link text,
+    Rinku.auto_link(
+      text,
       options[:link],
       tag_options(options[:html]),
       options[:skip],
       &block
+    ).html_safe
   end
 end
 


### PR DESCRIPTION
I've seen #14 but I don't think Rinku is behaving in the expected way. The existing code simply marks any potentially dangerous input as safe, processes it and returns it.

I think it should encode input that's not marked html_safe and then always return text that's marked html_safe. The attached code does this.

Sorry for the lack of tests but RailsRinku is not currently tested and I wasn't entirely sure how to set up the tests for that module.
