### PR TITLE
Being serious about UTF-8 compatibility

### DIFF
--- a/ext/rinku/rinku.c
+++ b/ext/rinku/rinku.c
@@ -25,7 +25,8 @@
 #else
 #define rb_enc_copy(dst, src)
 #define rb_enc_str_new(dst, src, enc) rb_str_new(dst, src)
-#define rb_enc_compatible(str1, str2) 1
+#define rb_enc_asciicompat(str1) 1
+#define rb_enc_get(str) 1
 #define rb_enc_set_index(str, idx)
 #define rb_enc_get_index(str) 1
 #endif
@@ -39,7 +40,6 @@
 #include <ctype.h>
 
 static VALUE rb_mRinku;
-static VALUE umlaut;
 
 typedef enum {
 	HTML_TAG_NONE = 0,
@@ -296,7 +296,7 @@ rinku_autolink(
 static void
 check_utf8(VALUE str)
 {
-  if(!rb_enc_compatible(umlaut, str)) {
+  if(!rb_enc_asciicompat(rb_enc_get(str))) {
 		rb_raise(rb_eArgError,
 			"Invalid encoding");
   }
@@ -482,7 +482,6 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 void RUBY_EXPORT Init_rinku()
 {
 	rb_mRinku = rb_define_module("Rinku");
-	umlaut = rb_enc_str_new("ü", 1, rb_utf8_encoding());
 	rb_define_method(rb_mRinku, "auto_link", rb_rinku_autolink, -1);
 	rb_define_const(rb_mRinku, "AUTOLINK_SHORT_DOMAINS", INT2FIX(SD_AUTOLINK_SHORT_DOMAINS));
 }

--- a/ext/rinku/rinku.c
+++ b/ext/rinku/rinku.c
@@ -24,6 +24,10 @@
 #include <ruby/encoding.h>
 #else
 #define rb_enc_copy(dst, src)
+#define rb_enc_str_new(dst, src, enc) rb_str_new(dst, src)
+#define rb_enc_compatible(str1, str2) 1
+#define rb_enc_set_index(str, idx)
+#define rb_enc_get_index(str) 1
 #endif
 
 #include "autolink.h"
@@ -35,6 +39,7 @@
 #include <ctype.h>
 
 static VALUE rb_mRinku;
+static VALUE umlaut;
 
 typedef enum {
 	HTML_TAG_NONE = 0,
@@ -74,7 +79,7 @@ static const char *g_hrefs[] = {
 };
 
 static void
-autolink__print(struct buf *ob, const struct buf *link, void *payload)
+autolink__print(struct buf *ob, const struct buf *link, void *payload, int enc_index)
 {
 	bufput(ob, link->data, link->size);
 }
@@ -191,7 +196,8 @@ rinku_autolink(
 	unsigned int flags,
 	const char *link_attr,
 	const char **skip_tags,
-	void (*link_text_cb)(struct buf *ob, const struct buf *link, void *payload),
+	void (*link_text_cb)(struct buf *ob, const struct buf *link, void *payload, int enc_index),
+	int enc_index,
 	void *payload)
 {
 	size_t i, end;
@@ -267,7 +273,7 @@ rinku_autolink(
 				BUFPUTSL(ob, "\">");
 			}
 
-			link_text_cb(ob, link, payload);
+			link_text_cb(ob, link, payload, enc_index);
 			BUFPUTSL(ob, "</a>");
 
 			link_count++;
@@ -286,11 +292,22 @@ rinku_autolink(
 /**
  * Ruby code
  */
+
 static void
-autolink_callback(struct buf *link_text, const struct buf *link, void *block)
+check_utf8(VALUE str)
+{
+  if(!rb_enc_compatible(umlaut, str)) {
+		rb_raise(rb_eArgError,
+			"Invalid encoding");
+  }
+}
+
+static void
+autolink_callback(struct buf *link_text, const struct buf *link, void *block, int enc_index)
 {
 	VALUE rb_link, rb_link_text;
 	rb_link = rb_str_new(link->data, link->size);
+	rb_enc_set_index(rb_link, enc_index);
 	rb_link_text = rb_funcall((VALUE)block, rb_intern("call"), 1, rb_link);
 	Check_Type(rb_link_text, T_STRING);
 	bufput(link_text, RSTRING_PTR(rb_link_text), RSTRING_LEN(rb_link_text));
@@ -346,8 +363,8 @@ const char **rinku_load_tags(VALUE rb_skip)
  * HTML, Rinku is smart enough to skip the links that are already enclosed in `<a>`
  * tags.`
  *
- * -   `mode` is a symbol, either `:all`, `:urls` or `:email_addresses`, 
- * which specifies which kind of links will be auto-linked. 
+ * -   `mode` is a symbol, either `:all`, `:urls` or `:email_addresses`,
+ * which specifies which kind of links will be auto-linked.
  *
  * -   `link_attr` is a string containing the link attributes for each link that
  * will be generated. These attributes are not sanitized and will be include as-is
@@ -392,9 +409,10 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 	ID mode_sym;
 
 	rb_scan_args(argc, argv, "14&", &rb_text, &rb_mode,
-		&rb_html, &rb_skip, &rb_flags, &rb_block); 
+		&rb_html, &rb_skip, &rb_flags, &rb_block);
 
 	Check_Type(rb_text, T_STRING);
+	check_utf8(rb_text);
 
 	if (!NIL_P(rb_mode)) {
 		Check_Type(rb_mode, T_SYMBOL);
@@ -434,6 +452,7 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 		rb_raise(rb_eTypeError,
 			"Invalid linking mode (possible values are :all, :urls, :email_addresses)");
 
+
 	count = rinku_autolink(
 		output_buf,
 		RSTRING_PTR(rb_text),
@@ -443,6 +462,7 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 		link_attr,
 		skip_tags,
 		RTEST(rb_block) ? &autolink_callback : NULL,
+		rb_enc_get_index(rb_text),
 		(void*)rb_block);
 
 	if (count == 0)
@@ -462,7 +482,7 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 void RUBY_EXPORT Init_rinku()
 {
 	rb_mRinku = rb_define_module("Rinku");
+	umlaut = rb_enc_str_new("ü", 1, rb_utf8_encoding());
 	rb_define_method(rb_mRinku, "auto_link", rb_rinku_autolink, -1);
 	rb_define_const(rb_mRinku, "AUTOLINK_SHORT_DOMAINS", INT2FIX(SD_AUTOLINK_SHORT_DOMAINS));
 }
-

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -149,6 +149,24 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     assert_equal link, "Find ur favorite pokeman @ <a href=\"http://www.pokemon.com\">POKEMAN WEBSITE</a>"
   end
 
+  def test_block_encoding
+    url = "http://example.com/х"
+    assert_equal "UTF-8", url.encoding.to_s
+
+    link = Rinku.auto_link(url) do |url|
+      assert_equal "UTF-8", url.encoding.to_s
+      url
+    end
+
+    assert_equal link.encoding.to_s, "UTF-8"
+  end
+
+  def test_links_with_cyrillic_x
+    url = "http://example.com/х"
+
+    assert_linked "<a href=\"#{url}\">#{url}</a>", url
+  end
+
   def test_autolink_works
     url = "http://example.com/"
     assert_linked "<a href=\"#{url}\">#{url}</a>", url

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -310,7 +310,7 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     end
 
     def test_bad_encoding
-      url = "http://example.com/ümlaut".encode("ISO-8859-1")
+      url = "http://example.com/ümlaut".encode("UTF-16")
       assert_raise ArgumentError do
         Rinku.auto_link(url)
       end

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -32,7 +32,7 @@ class RedcarpetAutolinkTest < Test::Unit::TestCase
     Rinku.skip_tags = nil
     assert_not_equal Rinku.auto_link(url), url
   end
-  
+
   def test_auto_link_with_single_trailing_punctuation_and_space
     url = "http://www.youtube.com"
     url_result = generate_result(url)
@@ -138,7 +138,7 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     url2 = "http://www.ruby-doc.org/core/Bar.html"
 
     assert_equal %(<p><a href="#{url1}">#{url1}</a><br /><a href="#{url2}">#{url2}</a><br /></p>), Rinku.auto_link("<p>#{url1}<br />#{url2}<br /></p>")
-  end  
+  end
 
   def test_block
     link = Rinku.auto_link("Find ur favorite pokeman @ http://www.pokemon.com") do |url|
@@ -147,24 +147,6 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     end
 
     assert_equal link, "Find ur favorite pokeman @ <a href=\"http://www.pokemon.com\">POKEMAN WEBSITE</a>"
-  end
-
-  def test_block_encoding
-    url = "http://example.com/х"
-    assert_equal "UTF-8", url.encoding.to_s
-
-    link = Rinku.auto_link(url) do |url|
-      assert_equal "UTF-8", url.encoding.to_s
-      url
-    end
-
-    assert_equal link.encoding.to_s, "UTF-8"
-  end
-
-  def test_links_with_cyrillic_x
-    url = "http://example.com/х"
-
-    assert_linked "<a href=\"#{url}\">#{url}</a>", url
   end
 
   def test_autolink_works
@@ -302,6 +284,36 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
 
       ret = Rinku.auto_link str
       assert_equal str.encoding, ret.encoding
+    end
+
+    def test_block_encoding
+      url = "http://example.com/х"
+      assert_equal "UTF-8", url.encoding.to_s
+
+      link = Rinku.auto_link(url) do |u|
+        assert_equal "UTF-8", u.encoding.to_s
+        u
+      end
+
+      assert_equal link.encoding.to_s, "UTF-8"
+
+      url = "http://www.bash.org"
+      url.encode! 'binary'
+
+      link = Rinku.auto_link(url) do |u|
+        assert_equal url.encoding.to_s, u.encoding.to_s
+        u
+      end
+
+      assert_equal url.encoding, link.encoding
+
+    end
+
+    def test_bad_encoding
+      url = "http://example.com/ümlaut".encode("ISO-8859-1")
+      assert_raise ArgumentError do
+        Rinku.auto_link(url)
+      end
     end
   end
 


### PR DESCRIPTION
Also copying incoming encoding to string yielded to the passed block.

This replaces #27, except for the autolink changes needed for supporting unicode text.