### PR TITLE
add ISC license metadata to gemspec

### DIFF
--- a/rinku.gemspec
+++ b/rinku.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.email = 'vicent@github.com'
   s.homepage = 'https://github.com/vmg/rinku'
   s.authors = ["Vicent Marti"]
+  s.license = 'ISC'
   # = MANIFEST =
   s.files = %w[
     COPYING


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.