### PR TITLE
use HTTPS for URL in gemspec

### DIFF
--- a/rinku.gemspec
+++ b/rinku.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
     acts as a drop-in replacement for Rails `auto_link`
   EOF
   s.email = 'vicent@github.com'
-  s.homepage = 'http://github.com/vmg/rinku'
+  s.homepage = 'https://github.com/vmg/rinku'
   s.authors = ["Vicent Marti"]
   # = MANIFEST =
   s.files = %w[


### PR DESCRIPTION
This pull request updates the rinku gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.
