### PR TITLE
Failing test for termination on ampersand

### DIFF
--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -185,6 +185,11 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     assert_linked "<a href=\"#{url}\">#{url}</a>", url
   end
 
+  def test_terminates_on_ampersand
+    url = "http://example.com"
+    assert_linked "hello &#39;<a href=\"#{url}\">#{url}</a>&#39; hello", "hello &#39;#{url}&#39; hello"
+  end
+
   def test_does_not_include_trailing_gt
     url = "http://example.com"
     assert_linked "&lt;<a href=\"#{url}\">#{url}</a>&gt;", "&lt;#{url}&gt;"


### PR DESCRIPTION
As this failing test states there is a problem with termination on ampersand.

This string `&39;http://example.com&39;` should be linked as `&39;<a href="http://example.com">http://example.com</a>&39;`.

Currently the &39 is being considered part of the domain, which it is not. `example.com&39` is not a valid domain.

Any pointers to fixing it would be great.