### PR TITLE
Fix #42 - ampersand termination bug

### DIFF
--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -67,7 +67,7 @@ autolink_delim(uint8_t *data, size_t link_end, size_t offset, size_t size)
 		else if (data[link_end - 1] == ';') {
 			size_t new_end = link_end - 2;
 
-			while (new_end > 0 && isalpha(data[new_end]))
+			while (new_end > 0 && (isalnum(data[new_end]) || data[new_end] == '#'))
 				new_end--;
 
 			if (new_end < link_end - 2 && data[new_end] == '&')

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -32,7 +32,7 @@ class RedcarpetAutolinkTest < Test::Unit::TestCase
     Rinku.skip_tags = nil
     assert_not_equal Rinku.auto_link(url), url
   end
-  
+
   def test_auto_link_with_single_trailing_punctuation_and_space
     url = "http://www.youtube.com"
     url_result = generate_result(url)
@@ -138,7 +138,7 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     url2 = "http://www.ruby-doc.org/core/Bar.html"
 
     assert_equal %(<p><a href="#{url1}">#{url1}</a><br /><a href="#{url2}">#{url2}</a><br /></p>), Rinku.auto_link("<p>#{url1}<br />#{url2}<br /></p>")
-  end  
+  end
 
   def test_block
     link = Rinku.auto_link("Find ur favorite pokeman @ http://www.pokemon.com") do |url|
@@ -177,6 +177,11 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
   def test_does_not_terminate_on_dash
     url = "http://example.com/Notification_Center-GitHub-20101108-140050.jpg"
     assert_linked "<a href=\"#{url}\">#{url}</a>", url
+  end
+
+  def test_terminates_on_ampersand
+    url = "http://example.com"
+    assert_linked "hello &#39;<a href=\"#{url}\">#{url}</a>&#39; hello", "hello &#39;#{url}&#39; hello"
   end
 
   def test_does_not_include_trailing_gt


### PR DESCRIPTION
Issue: https://github.com/vmg/rinku/pull/42

The fix handles escaped UTF-8 and special characters in a link.

/cc @vmg @shajith @staugaard