### PR TITLE
add rake compiler to devel deps, and add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/rinku.gemspec
+++ b/rinku.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["COPYING"]
   s.extensions = ["ext/rinku/extconf.rb"]
   s.require_paths = ["lib"]
+  s.add_development_dependency("rake-compiler")
 end


### PR DESCRIPTION
The Rakefile loads `rake/extensiontask` which is present in the rake-compiler gem. The first commit in this PR adds a development dependency on this gem so that bundler will pull it in for the build.

This second commit in this PR adds a `Gemfile` to the tree. Prior to this change, Travis CI would not use bundler to install any dependencies in the gemspec.