### PR TITLE
tests: switch to minitest 5

### DIFF
--- a/rinku.gemspec
+++ b/rinku.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/rinku/extconf.rb"]
   s.require_paths = ["lib"]
   s.add_development_dependency("rake-compiler")
+  s.add_development_dependency("minitest")
 end

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -2,12 +2,12 @@
 rootdir = File.dirname(File.dirname(__FILE__))
 $LOAD_PATH.unshift "#{rootdir}/lib"
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'cgi'
 require 'uri'
 require 'rinku'
 
-class RedcarpetAutolinkTest < Test::Unit::TestCase
+class RedcarpetAutolinkTest < Minitest::Test
 
   SAFE_CHARS = "{}[]~'"
 
@@ -34,7 +34,7 @@ class RedcarpetAutolinkTest < Test::Unit::TestCase
     assert_equal Rinku.auto_link(url), url
 
     Rinku.skip_tags = nil
-    assert_not_equal Rinku.auto_link(url), url
+    refute_equal Rinku.auto_link(url), url
   end
 
   def test_auto_link_with_single_trailing_punctuation_and_space


### PR DESCRIPTION
Ruby 1.9+ uses Minitest as the backend for Test::Unit, so we might as well update to the Minitest 5 API.

It would be a good idea to merge #47 before merging this PR. This PR will need a small rebase to account for the rake-compiler addition in `rinku.gemspec`.