### PR TITLE
Don't email autolink if only period is at end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ruby-version
 lib/rinku.bundle
 tmp/
+Gemfile.lock

--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -244,7 +244,7 @@ autolink__email(
 			break;
 	}
 
-	if ((link->end - pos) < 2 || nb != 1 || np == 0)
+	if ((link->end - pos) < 2 || nb != 1 || np == 0 || (np == 1 && data[link->end - 1] == '.'))
 		return false;
 
 	return autolink_delim(data, link);

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -376,4 +376,13 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     url = "WwW.reddit.CoM"
     assert_linked generate_result(url), url
   end
+
+  def test_non_emails_ending_in_periods
+    assert_linked "abc/def@ghi.", "abc/def@ghi."
+    assert_linked "abc/def@ghi. ", "abc/def@ghi. "
+    assert_linked "abc/def@ghi. x", "abc/def@ghi. x"
+    assert_linked "abc/def@ghi.< x", "abc/def@ghi.< x"
+    assert_linked "abc/<a href=\"mailto:def@ghi.x\">def@ghi.x</a>", "abc/def@ghi.x"
+    assert_linked "abc/<a href=\"mailto:def@ghi.x\">def@ghi.x</a>. a", "abc/def@ghi.x. a"
+  end
 end


### PR DESCRIPTION
See test case:

``` ruby
  def test_non_emails_ending_in_periods
    assert_linked "abc/def@ghi.", "abc/def@ghi."
    assert_linked "abc/def@ghi. ", "abc/def@ghi. "
    assert_linked "abc/def@ghi. x", "abc/def@ghi. x"
    assert_linked "abc/def@ghi.< x", "abc/def@ghi.< x"
    assert_linked "abc/<a href=\"mailto:def@ghi.x\">def@ghi.x</a>", "abc/def@ghi.x"
    assert_linked "abc/<a href=\"mailto:def@ghi.x\">def@ghi.x</a>. a", "abc/def@ghi.x. a"
  end
```
