### PR TITLE
make tests run ... they fail with minitest 4

### DIFF
--- a/rinku.gemspec
+++ b/rinku.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rake-compiler"
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest", ">= 5.0"
 end

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
-rootdir = File.dirname(File.dirname(__FILE__))
-$LOAD_PATH.unshift "#{rootdir}/lib"
+require 'bundler/setup'
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'minitest/autorun'
 require 'cgi'


### PR DESCRIPTION
@vmg 

```
vendor/bundle/gems/minitest-4.7.5/lib/minitest/unit.rb:19:in `const_missing': uninitialized constant MiniTest::Test (NameError)
	from test/autolink_test.rb:9:in `<top (required)>'
```