### PR TITLE
Handle entities+parens, or multiple entities in URLs

### DIFF
--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -140,6 +140,25 @@ autolink_delim(const uint8_t *data, struct autolink_pos *link)
 }
 
 static bool
+autolink_delim_iter(const uint8_t *data, struct autolink_pos *link)
+{
+	size_t prev_link_end;
+	int iterations = 0;
+	autolink_delim(data, link);
+
+	while(link->end != 0) {
+		prev_link_end = link->end;
+		autolink_delim(data, link);
+		if (prev_link_end == link->end || iterations > 5) {
+			break;
+		}
+		iterations++;
+	}
+
+	return true;
+}
+
+static bool
 check_domain(const uint8_t *data, size_t size,
 		struct autolink_pos *link, bool allow_short)
 {
@@ -198,7 +217,7 @@ autolink__www(
 		return false;
 
 	link->end = utf8proc_find_space(data, link->end, size);
-	return autolink_delim(data, link);
+	return autolink_delim_iter(data, link);
 }
 
 bool
@@ -278,5 +297,5 @@ autolink__url(
 	if (!autolink_issafe(data + link->start, size - link->start))
 		return false;
 
-	return autolink_delim(data, link);
+	return autolink_delim_iter(data, link);
 }

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -385,4 +385,13 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     assert_linked "abc/<a href=\"mailto:def@ghi.x\">def@ghi.x</a>", "abc/def@ghi.x"
     assert_linked "abc/<a href=\"mailto:def@ghi.x\">def@ghi.x</a>. a", "abc/def@ghi.x. a"
   end
+
+  def test_urls_with_entities_and_parens
+    assert_linked "&lt;<a href=\"http://www.google.com\">http://www.google.com</a>&gt;", "&lt;http://www.google.com&gt;"
+
+    assert_linked "&lt;<a href=\"http://www.google.com\">http://www.google.com</a>&gt;)", "&lt;http://www.google.com&gt;)"
+
+    # this produces invalid output, but limits how much work we will do
+    assert_linked "&lt;<a href=\"http://www.google.com&gt;\">http://www.google.com&gt;</a>)&lt;)&lt;)&lt;)&lt;)&lt;)&lt;)", "&lt;http://www.google.com&gt;)&lt;)&lt;)&lt;)&lt;)&lt;)&lt;)"
+  end
 end


### PR DESCRIPTION
Calling autolink_delim multiple times instead of just once, until we
find no more delimiters.

/cc @jcheatham @shajith


the last test is failing with this but I'm not sure why:

```
--- expected
+++ actual
@@ -1 +1 @@
-"&lt;<a href=\"http://www.google.com&gt;\">http://www.google.com&gt;</a>)&lt;)&lt;)&lt;)&lt;)&lt;)&lt;)"
+"&lt;<a href=\"http://www.google.com\">http://www.google.com</a>&gt;&lt;&lt;&lt;&lt;&lt;&lt;"
```

[original commit](https://github.com/zendesk/rinku/commit/9f740cc08917c11f255cbf277f86d17a8c1a42f2) had the iter patch in only www ... but we had to add it into url to make it work at all ...