### PR TITLE
Support for UTF-8 parens

### DIFF
--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -124,8 +124,14 @@ autolink_delim(const uint8_t *data, struct autolink_pos *link)
 				closing++;
 		}
 
-		if (closing > opening)
-			utf8proc_back(data, &link->end);
+		if (copen == cclose) {
+			if (opening > 0)
+				utf8proc_back(data, &link->end);
+		}
+		else {
+			if (closing > opening)
+				utf8proc_back(data, &link->end);
+		}
 	}
 
 	return true;

--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -52,7 +52,7 @@ autolink_issafe(const uint8_t *link, size_t link_len)
 static bool
 autolink_delim(const uint8_t *data, struct autolink_pos *link)
 {
-	uint8_t cclose, copen = 0;
+	int32_t cclose, copen = 0;
 	size_t i;
 
 	for (i = link->start; i < link->end; ++i)
@@ -88,15 +88,8 @@ autolink_delim(const uint8_t *data, struct autolink_pos *link)
 	if (link->end == link->start)
 		return false;
 
-	cclose = data[link->end - 1];
-
-	switch (cclose) {
-	case '"':	copen = '"'; break;
-	case '\'':	copen = '\''; break;
-	case ')':	copen = '('; break;
-	case ']':	copen = '['; break;
-	case '}':	copen = '{'; break;
-	}
+	cclose = utf8proc_rewind(data, link->end);
+	copen = utf8proc_open_paren_character(cclose);
 
 	if (copen != 0) {
 		/* Try to close the final punctuation sign in this link; if
@@ -124,16 +117,15 @@ autolink_delim(const uint8_t *data, struct autolink_pos *link)
 		size_t i = link->start;
 
 		while (i < link->end) {
-			if (data[i] == copen)
+			int32_t c = utf8proc_next(data, &i);
+			if (c == copen)
 				opening++;
-			else if (data[i] == cclose)
+			else if (c == cclose)
 				closing++;
-
-			i++;
 		}
 
 		if (closing > opening)
-			link->end--;
+			utf8proc_back(data, &link->end);
 	}
 
 	return true;

--- a/ext/rinku/utf8.h
+++ b/ext/rinku/utf8.h
@@ -26,8 +26,11 @@ bool rinku_isalpha(char c);
 bool rinku_isalnum(char c);
 
 int32_t utf8proc_rewind(const uint8_t *data, size_t pos);
+int32_t utf8proc_next(const uint8_t *str, size_t *pos);
+int32_t utf8proc_back(const uint8_t *data, size_t *pos);
 size_t utf8proc_find_space(const uint8_t *str, size_t pos, size_t size);
 
+int32_t utf8proc_open_paren_character(int32_t cclose);
 bool utf8proc_is_space(int32_t uc);
 bool utf8proc_is_punctuation(int32_t uc);
 

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -412,4 +412,17 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     assert_linked "URL is #{generate_result(url, "mailto:#{url}")}.", "URL is #{url}."
     assert_linked "(URL is #{generate_result(url, "mailto:#{url}")}.)", "(URL is #{url}.)"
   end
+
+  def test_urls_with_parens
+    assert_linked "(<a href=\"http://example.com\">http://example.com</a>)", "(http://example.com)"
+    assert_linked "((<a href=\"http://example.com/()\">http://example.com/()</a>))", "((http://example.com/()))"
+    assert_linked "[<a href=\"http://example.com/()\">http://example.com/()</a>]", "[http://example.com/()]"
+
+    assert_linked "（<a href=\"http://example.com/\">http://example.com/</a>）", "（http://example.com/）"
+    assert_linked "【<a href=\"http://example.com/\">http://example.com/</a>】", "【http://example.com/】"
+    assert_linked "『<a href=\"http://example.com/\">http://example.com/</a>』", "『http://example.com/』"
+    assert_linked "「<a href=\"http://example.com/\">http://example.com/</a>」", "「http://example.com/」"
+    assert_linked "《<a href=\"http://example.com/\">http://example.com/</a>》", "《http://example.com/》"
+    assert_linked "〈<a href=\"http://example.com/\">http://example.com/</a>〉", "〈http://example.com/〉"
+  end
 end

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -425,4 +425,9 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
     assert_linked "《<a href=\"http://example.com/\">http://example.com/</a>》", "《http://example.com/》"
     assert_linked "〈<a href=\"http://example.com/\">http://example.com/</a>〉", "〈http://example.com/〉"
   end
+
+  def test_urls_with_quotes
+    assert_linked "'<a href=\"http://example.com\">http://example.com</a>'", "'http://example.com'"
+    assert_linked "\"<a href=\"http://example.com\">http://example.com</a>\"\"", "\"http://example.com\"\""
+  end
 end


### PR DESCRIPTION
...including fix of #67.

It doesn't matter to this PR, but those parsing process looks a bit weird to me.. As Japanese text can include letters (non-space UTF-8 characters) right after closing parentheses, to split a text by spaces first of all seems not to be a good way of doing it. I'd be happy if you could take a look at this issue.