### PR TITLE
Use tag_builder for Rails support in >5.1.0

### DIFF
--- a/lib/rails_rinku.rb
+++ b/lib/rails_rinku.rb
@@ -16,7 +16,7 @@ module RailsRinku
     Rinku.auto_link(
       text,
       options[:link],
-      tag_options(options[:html]),
+      tag_builder.tag_options(options[:html]),
       options[:skip],
       &block
     ).html_safe


### PR DESCRIPTION
This will resolve #70.

Only concern with this is that it will break in Rails <5, and `rinku` doesn't specify any rails dependency versions. That's up to the maintainers to work out though I think. Personally I'd specify `rails_rinku` as a separate gem that has this code in it, and specifies rails versions properly, but it's up to you.