### PR TITLE
Autolink sftp and ftps protocols

### DIFF
--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -38,9 +38,9 @@ is_valid_hostchar(const uint8_t *link, size_t link_len)
 bool
 autolink_issafe(const uint8_t *link, size_t link_len)
 {
-	static const size_t valid_uris_count = 5;
+	static const size_t valid_uris_count = 7;
 	static const char *valid_uris[] = {
-		"/", "http://", "https://", "ftp://", "mailto:"
+		"/", "http://", "https://", "ftp://", "sftp://", "ftps://", "mailto:"
 	};
 
 	size_t i;

--- a/ext/rinku/rinku_rb.c
+++ b/ext/rinku/rinku_rb.c
@@ -105,7 +105,7 @@ const char **rinku_load_tags(VALUE rb_skip)
  * NOTE: Currently the follow protocols are considered safe and are the
  * only ones that will be autolinked.
  *
- *     http:// https:// ftp:// mailto://
+ *     http:// https:// ftp:// sftp:// ftps:// mailto://
  *
  * Email addresses are also autolinked by default. URLs without a protocol
  * specifier but starting with 'www.' will also be autolinked, defaulting to
@@ -115,8 +115,8 @@ const char **rinku_load_tags(VALUE rb_skip)
  * HTML, Rinku is smart enough to skip the links that are already enclosed in `<a>`
  * tags.`
  *
- * -   `mode` is a symbol, either `:all`, `:urls` or `:email_addresses`, 
- * which specifies which kind of links will be auto-linked. 
+ * -   `mode` is a symbol, either `:all`, `:urls` or `:email_addresses`,
+ * which specifies which kind of links will be auto-linked.
  *
  * -   `link_attr` is a string containing the link attributes for each link that
  * will be generated. These attributes are not sanitized and will be include as-is
@@ -162,7 +162,7 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 	struct callback_data cbdata;
 
 	rb_scan_args(argc, argv, "14&", &rb_text, &rb_mode,
-		&rb_html, &rb_skip, &rb_flags, &rb_block); 
+		&rb_html, &rb_skip, &rb_flags, &rb_block);
 
 	text_encoding = validate_encoding(rb_text);
 
@@ -236,4 +236,3 @@ void RUBY_EXPORT Init_rinku()
 	rb_define_module_function(rb_mRinku, "auto_link", rb_rinku_autolink, -1);
 	rb_define_const(rb_mRinku, "AUTOLINK_SHORT_DOMAINS", INT2FIX(AUTOLINK_SHORT_DOMAINS));
 }
-

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -438,4 +438,16 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
   def test_underscore_in_subdomain
     assert_linked "<a href=\"http://foo_bar.xyz.com\">http://foo_bar.xyz.com</a>", "http://foo_bar.xyz.com"
   end
+
+  def test_ftp_autolink
+    assert_linked "<a href=\"ftp://foo.bar\">ftp://foo.bar</a>", "ftp://foo.bar"
+  end
+
+  def test_sftp_autolink
+    assert_linked "<a href=\"sftp://foo.bar\">sftp://foo.bar</a>", "sftp://foo.bar"
+  end
+
+  def test_ftps_autolink
+    assert_linked "<a href=\"ftps://foo.bar\">ftps://foo.bar</a>", "ftps://foo.bar"
+  end
 end


### PR DESCRIPTION
Currently, only ftp protocol is auto linked. This PR is adding also sftp and ftps protocols.

Also, is adding a test for the ftp protocol. 