### PR TITLE
fix infinite loop

### DIFF
--- a/ext/rinku/utf8.c
+++ b/ext/rinku/utf8.c
@@ -104,7 +104,9 @@ size_t utf8proc_find_space(const uint8_t *str, size_t pos, size_t size)
 	while (pos < size) {
 		const size_t last = pos;
 		int32_t uc = utf8proc_next(str, &pos);
-		if (utf8proc_is_space(uc))
+		if (uc == 0xFFFD)
+			return size;
+		else if (utf8proc_is_space(uc))
 			return last;
 	}
 	return size;

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -27,7 +27,7 @@ class RinkuAutoLinkTest < Minitest::Test
   end
 
   def test_global_skip_tags
-    assert_equal Rinku.skip_tags, nil
+    assert_nil Rinku.skip_tags
     Rinku.skip_tags = ['pre']
     assert_equal Rinku.skip_tags, ['pre']
 

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -438,4 +438,8 @@ This is just a test. <a href="http://www.pokemon.com">http://www.pokemon.com</a>
   def test_underscore_in_subdomain
     assert_linked "<a href=\"http://foo_bar.xyz.com\">http://foo_bar.xyz.com</a>", "http://foo_bar.xyz.com"
   end
+
+  def test_regression_84
+    assert_linked "<a href=\"https://www.keepright.atの情報をもとにエラー修正\">https://www.keepright.atの情報をもとにエラー修正</a>", "https://www.keepright.atの情報をもとにエラー修正"
+  end
 end


### PR DESCRIPTION
The UTF-8 processor can get stuck if we try to find spaces in the middle of a sequence. Fixes #84.