### PR TITLE
Support possible German umlauts in email address strings

### DIFF
--- a/ext/rinku/autolink.c
+++ b/ext/rinku/autolink.c
@@ -255,7 +255,7 @@ autolink__email(
 		if (rinku_isalnum(c))
 			continue;
 
-		if (strchr(".+-_%", c) != NULL)
+		if (strchr(".+-_%äöüß", c) != NULL)
 			continue;
 
 		break;

--- a/test/autolink_test.rb
+++ b/test/autolink_test.rb
@@ -53,6 +53,11 @@ class RinkuAutoLinkTest < Minitest::Test
     assert_linked "hello &#39;<a href=\"#{url}\">#{url}</a>&#39; hello", "hello &#39;#{url}&#39; hello"
   end
 
+  def test_auto_link_email_can_handle_international_accepted_characters
+    address = "björn-jürgen.nußbaum@example.com"
+    assert_linked "<a href=\"mailto:#{address}\">#{address}</a>", address
+  end
+
   def test_does_not_segfault
     assert_linked "< this is just a test", "< this is just a test"
   end


### PR DESCRIPTION
In German language, and of course in many others, there are special characters, i.e. the so-called [umlauts](https://en.wikipedia.org/wiki/Umlaut_(linguistics)) in case of German.

Under some circumstances these characters are supported by modern SMTP servers, see i.e. [this discussion](https://stackoverflow.com/a/15152095/2159942). ([this](https://www.jochentopf.com/email/chars.html) is also an interesting related read)

We are also experiencing this within our data, but unfortunately `rinku`s auto_link mechanics fail to handle email addresses for mailto-links correctly, if the email address contains an umlaut.  

### Current behavior

```Ruby
Rinku.auto_link("björn-jürgen.nußbaum@example.com") 
# björn-jürgen.nuß<a href="mailto:naum@example.com">naum@example.com</a>
```
### Expected behavior

```Ruby
Rinku.auto_link("björn-jürgen.nußbaum@example.com") 
# <a href="mailto:björn-jürgen.nußbaum@example.com">björn-jürgen.nußbaum@example.com</a>
```

### Discussion

Our PR is restricted only on the case of German umlauts, but of course we see that a wider range of characters are affected for other languages, i.e. `ñ` or cases like `é`. We were not 100% certain how to proceed for this and would be happy for some advice. Is the approach we've taken in the code, namely extending the lookup for special characters, the right one here? 

Maybe we're on the wrong track and the support for those characters should get added to rinkus `rinku_isalnum()` function. What do you think? 
