### PR TITLE
Prefer the source of the #h alias

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem "cgi"
+gem "minitest", ">= 5.0"
+gem "rake"
+gem "rake-compiler"

--- a/ext/rinku/rinku_rb.c
+++ b/ext/rinku/rinku_rb.c
@@ -15,8 +15,6 @@
  */
 #include <stdio.h>
 
-#define RUBY_EXPORT __attribute__ ((visibility ("default")))
-
 #include <ruby.h>
 #include <ruby/encoding.h>
 
@@ -230,7 +228,7 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 	return result;
 }
 
-void RUBY_EXPORT Init_rinku()
+void RUBY_FUNC_EXPORTED Init_rinku()
 {
 	rb_mRinku = rb_define_module("Rinku");
 	rb_define_module_function(rb_mRinku, "auto_link", rb_rinku_autolink, -1);

--- a/lib/rails_rinku.rb
+++ b/lib/rails_rinku.rb
@@ -11,7 +11,7 @@ module RailsRinku
       options[:skip] = args[2]
     end
     options.reverse_merge!(:link => :all, :html => {})
-    text = h(text) unless text.html_safe?
+    text = ERB::Util.html_escape(text) unless text.html_safe?
 
     tag_options_method = if Gem::Version.new(Rails.version) >= Gem::Version.new("5.1")
       # Rails >= 5.1

--- a/rinku.gemspec
+++ b/rinku.gemspec
@@ -36,9 +36,5 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/rinku/extconf.rb"]
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rake"
-  s.add_development_dependency "rake-compiler"
-  s.add_development_dependency "minitest", ">= 5.0"
-
   s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
I searched the API docs for Rails for the #h method. Turned out to be an alias to a longer-named method.

This change made my code work.

https://api.rubyonrails.org/classes/ERB/Util.html#method-c-h