### PR TITLE
Replace RUBY_EXPORT with RUBY_FUNC_EXPORTED since it's the recommended way

### DIFF
--- a/ext/rinku/rinku_rb.c
+++ b/ext/rinku/rinku_rb.c
@@ -15,8 +15,6 @@
  */
 #include <stdio.h>
 
-#define RUBY_EXPORT __attribute__ ((visibility ("default")))
-
 #include <ruby.h>
 #include <ruby/encoding.h>
 
@@ -230,7 +228,7 @@ rb_rinku_autolink(int argc, VALUE *argv, VALUE self)
 	return result;
 }
 
-void RUBY_EXPORT Init_rinku()
+void RUBY_FUNC_EXPORTED Init_rinku()
 {
 	rb_mRinku = rb_define_module("Rinku");
 	rb_define_module_function(rb_mRinku, "auto_link", rb_rinku_autolink, -1);


### PR DESCRIPTION
RUBY_EXPORT used by ruby internally to figure out if library is static or dynamic. The change in https://github.com/ruby/ruby/pull/9828 broke rinku because it couldn't find `ruby_abi_version()` anymore.

RUBY_FUNC_EXPORTED is recommended in that case
(see https://github.com/ruby/ruby/blob/b2392c6be418703e8941226ac80b359188bf3c5d/lib/bundler/templates/newgem/ext/newgem/extconf-c.rb.tt#L6)